### PR TITLE
Make alice-github stateless

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var auth_url = github.auth.config({
   id: process.env.GITHUB_CLIENT_ID,
   secret: process.env.GITHUB_SECRET,
   apiUrl: process.env.GITHUB_API
-}).login(['user']);
+}).login(['user:read']);
 
 function nocache(d) {
   var resp = {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var http   = require('http')
   , mysql  = require('mysql');
 
 // GITHUB_CLIENT_ID and GITHUB_SECRET should be registered in Github
-// GITHUB_API should be something like htts://github.com/api/v3
+// GITHUB_API should be something like https://github.com/api/v3
 // WEB_URL should be https:
 //  webUrl: 'https://optional-internal-github-enterprise'
 // Build the authorization config and url

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ http.createServer(function (req, res) {
           USER_DB[req.headers.adfs_login] = body.login;
           res.writeHead(302, nocache({'Content-Type': 'text/html',
                                       'Location': process.env.ALICE_GITHUB_PREFIX+'/whoami'}));
+          res.end('');
         });
       });
     }


### PR DESCRIPTION
Since the script which does the PR checking caches a full mapping of
CERN user to their Github counterparts, we do not need a stateful DB to
store that information. This will allow us to reduce moving parts and
reliance on an external MySQL instance.